### PR TITLE
Improve printing in UEFI.

### DIFF
--- a/bootloader/src/sys/fs.rs
+++ b/bootloader/src/sys/fs.rs
@@ -15,14 +15,11 @@ pub struct Error {}
 
 /// Reads the content of the file in `path` into a `Vec<u8>`
 pub fn read(path: &str) -> Result<Vec<u8>, Error> {
-    let mut walker = {
-        let table = SYSTEM_TABLE.get();
-        let mut fs = GlobalTable::open_protocol::<SimpleFileSystem>(&table)
-            .expect("Unable to open SimpleFileSystem protocol");
+    let table = SYSTEM_TABLE.get();
+    let mut fs = GlobalTable::open_protocol::<SimpleFileSystem>(&table)
+        .expect("Unable to open SimpleFileSystem protocol");
 
-        let walker = fs.open_volume().expect("Can't open volume.");
-        walker
-    };
+    let mut walker = fs.open_volume().expect("Can't open volume.");
 
     let mut it = path.split('/').peekable();
     while let Some(entry) = it.next() {

--- a/bootloader/src/sys/io.rs
+++ b/bootloader/src/sys/io.rs
@@ -1,25 +1,21 @@
 //! UEFI I/O utilities.
 
-use core::fmt::Write;
-
 use bootinfo::{Framebuffer, PixelBitmask, PixelFormat};
 use log::{Metadata, Record};
 use uefi::proto::console::gop::GraphicsOutput;
 
 use super::GlobalTable;
+use crate::println;
 use crate::sys::SYSTEM_TABLE;
 
 /// Retrieves the framebuffer. The framebuffer can be used after exiting boot services.
 pub fn get_framebuffer() -> Framebuffer {
-    let (framebuffer, mode) = {
-        let table = SYSTEM_TABLE.get();
-        let mut gop = GlobalTable::open_protocol::<GraphicsOutput>(&table)
-            .expect("Unable to open GraphicsOutput protocol");
+    let table = SYSTEM_TABLE.get();
+    let mut gop = GlobalTable::open_protocol::<GraphicsOutput>(&table)
+        .expect("Unable to open GraphicsOutput protocol");
 
-        let framebuffer = gop.frame_buffer().as_mut_ptr();
-        let mode = gop.current_mode_info();
-        (framebuffer, mode)
-    };
+    let framebuffer = gop.frame_buffer().as_mut_ptr();
+    let mode = gop.current_mode_info();
 
     Framebuffer {
         address: framebuffer,
@@ -65,15 +61,7 @@ impl log::Log for UefiLogger {
 
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
-            {
-                writeln!(
-                    SYSTEM_TABLE.get_mut().stdout(),
-                    "{} - {}",
-                    record.level(),
-                    record.args()
-                )
-                .expect("Unable to log to screen");
-            }
+            println!("{} - {}", record.level(), record.args()).unwrap();
         }
     }
 


### PR DESCRIPTION
It's unclear whether this is supposed to be undefined behavior or not. It seems to be working. This is still better than before since at least the printing is all done locally (i.e. there's no way to get an stdout handle that persists and thus could lead to multiple writers).