### PR TITLE
Read the initrd from the userspace booter component.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,7 @@ dependencies = [
  "log",
  "serial",
  "sync",
+ "tar-no-std",
 ]
 
 [[package]]
@@ -256,6 +257,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 name = "memory_manager"
 version = "0.1.0"
 dependencies = [
+ "entry",
  "kapi",
  "log",
  "serial",

--- a/harmony/entry/src/lib.rs
+++ b/harmony/entry/src/lib.rs
@@ -14,6 +14,10 @@ pub fn entry(_attr: TokenStream, fun: TokenStream) -> TokenStream {
         "Entry function must not specify an ABI"
     );
     assert!(
+        entry_fun.sig.abi.is_none(),
+        "Entry function must not specify an ABI"
+    );
+    assert!(
         entry_fun.attrs.is_empty(),
         "Attributes are not allowed on entry function"
     );

--- a/harmony/userspace/booter/Cargo.toml
+++ b/harmony/userspace/booter/Cargo.toml
@@ -9,3 +9,4 @@ sync = { workspace = true }
 serial = { workspace = true }
 entry = { workspace = true }
 log = "0.4.21"
+tar-no-std = "0.3.2"

--- a/harmony/userspace/booter/src/main.rs
+++ b/harmony/userspace/booter/src/main.rs
@@ -9,6 +9,7 @@ use kapi::raw::CapId;
 use kapi::userspace::cap_managment::{FrameAllocator, SelfCapabilityManager};
 use kapi::userspace::structures::PhysFrame;
 use kapi::userspace::Booter;
+use tar_no_std::TarArchiveRef;
 
 #[cfg(not(test))]
 #[panic_handler]
@@ -37,15 +38,34 @@ impl FrameAllocator for &'_ FrameBumper {
 }
 
 #[entry]
-fn main(lowest_frame: usize) -> ! {
+fn main(lowest_frame: usize, initrd: *const u8, initrd_size: usize) -> ! {
     let resources = Booter::make();
 
     resources.hardware.enable_ports().unwrap();
     serial::init();
 
+    // SAFETY: Passed initrd info from the kernel is correct.
+    let initrd = unsafe { core::slice::from_raw_parts(initrd, initrd_size) };
+    log::info!(
+        "Jumped to userspace: next_frame: {}, initrd: ({:?}, {})",
+        lowest_frame,
+        initrd.as_ptr(),
+        initrd.len()
+    );
+
     let frames = FrameBumper::new(PhysFrame::new(lowest_frame));
     let _cap_manager =
         SelfCapabilityManager::new_with_start(resources.self_caps, CapId::new(6), &frames);
+
+    let initrd = TarArchiveRef::new(initrd).expect("Bad initramfs");
+    let _memory_manager = initrd
+        .entries()
+        .find(|entry| {
+            entry.filename().as_str().expect("Invalid entry in initrd") == "memory_manager"
+        })
+        .expect("Missing memory_manager from initrd")
+        .data();
+
     log::info!("Initializing user space");
     loop {}
 }

--- a/harmony/userspace/memory_manager/Cargo.toml
+++ b/harmony/userspace/memory_manager/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 [dependencies]
 serial = { workspace = true }
 kapi = { workspace = true, features = ["userspace"] }
+entry = { workspace = true }
 log = "0.4.21"

--- a/harmony/userspace/memory_manager/src/main.rs
+++ b/harmony/userspace/memory_manager/src/main.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use entry::entry;
 use kapi::userspace::MemoryManager;
 
 #[cfg(not(test))]
@@ -12,8 +13,8 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
     loop {}
 }
 
-#[no_mangle]
-extern "C" fn _start() -> ! {
+#[entry]
+fn main() -> ! {
     let MemoryManager {
         sync_ret,
         self_caps,
@@ -21,7 +22,7 @@ extern "C" fn _start() -> ! {
         retype,
         hardware,
     } = MemoryManager::make();
-    hardware.enable_ports();
+    hardware.enable_ports().unwrap();
     serial::init();
     log::info!("Initializing memory manager");
     loop {}


### PR DESCRIPTION
Start the loading process by reading the initrd image
in the booter component. Later we will load the memory
manager, scheduler, etc.